### PR TITLE
Fix session_start() Notice

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -109,7 +109,9 @@ class Auth
                 // @codeCoverageIgnoreEnd
                 break;
             case PHP_SESSION_NONE:
-                session_start();
+                if (session_status() == PHP_SESSION_NONE) {
+                    session_start();
+                }
                 break;
         }
     }


### PR DESCRIPTION
In the latest development version of ATK UI and during exceptions, Auth->init() gets called twice. This fixes the notice by checking if session_start() is already active.