### PR TITLE
Fix log-in page title

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -85,13 +85,6 @@ class Auth
      * @var bool
      */
     public $hasPreferences = true;
-    
-    /**
-     * Page and form title
-     *
-     * @var string
-     */
-    public $title = 'Log-in Required';
 
     /**
      * Constructor.
@@ -215,7 +208,7 @@ class Auth
         }
 
         // if user is not logged in, then show login form
-        $l = new \atk4\ui\App($this->title);
+        $l = new \atk4\ui\App($this->app->title.' - Log-in Required');
         $this->app->catch_runaway_callbacks = false;
         $this->app->run_called = true;
         $l->catch_runaway_callbacks = false;
@@ -228,7 +221,7 @@ class Auth
             'linkForgot' => false,
         ]);
 
-        $l->layout->template->set('title', $this->title);
+        $l->layout->template->set('title', 'Log-in Required');
 
         $l->run();
         $this->app->terminate(); 

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -85,6 +85,13 @@ class Auth
      * @var bool
      */
     public $hasPreferences = true;
+    
+    /**
+     * Page and form title
+     *
+     * @var string
+     */
+    public $title = 'Log-in Required';
 
     /**
      * Constructor.
@@ -209,7 +216,7 @@ class Auth
 
         // if user is not logged in, then show login form
         $l = new \atk4\ui\App();
-        $l->title = 'Log-in Required';
+        $l->title = $this->title;
         $this->app->catch_runaway_callbacks = false;
         $this->app->run_called = true;
         $l->catch_runaway_callbacks = false;
@@ -222,7 +229,7 @@ class Auth
             'linkForgot' => false,
         ]);
 
-        $l->layout->template->set('title', 'Log-in Required');
+        $l->layout->template->set('title', $this->title);
 
         $l->run();
         $this->app->terminate(); 

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -215,8 +215,7 @@ class Auth
         }
 
         // if user is not logged in, then show login form
-        $l = new \atk4\ui\App();
-        $l->title = $this->title;
+        $l = new \atk4\ui\App($this->title);
         $this->app->catch_runaway_callbacks = false;
         $this->app->run_called = true;
         $l->catch_runaway_callbacks = false;

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -209,6 +209,7 @@ class Auth
 
         // if user is not logged in, then show login form
         $l = new \atk4\ui\App();
+        $l->title = 'Log-in Required';
         $this->app->catch_runaway_callbacks = false;
         $this->app->run_called = true;
         $l->catch_runaway_callbacks = false;


### PR DESCRIPTION
When login is rendered, the current page title is "Agile UI - Untitled Application". This PR displays the applications title, appending to it a "Log-in Required" string.