### PR TITLE
Fix recursion in ACL model

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -51,9 +51,6 @@ return (new PhpCsFixer\Config())
         'general_phpdoc_annotation_remove' => [
             'annotations' => ['author', 'copyright', 'throws'],
         ],
-        'nullable_type_declaration_for_default_null_value' => [
-            'use_nullable_type_declaration' => false,
-        ],
 
         // fn => without curly brackets is less readable,
         // also prevent bounding of unwanted variables for GC

--- a/demos/_demo-data/create-db.php
+++ b/demos/_demo-data/create-db.php
@@ -49,13 +49,12 @@ $model->addField('all_editable', ['type' => 'boolean']);
 $model->addField('editable_fields', ['type' => 'string']);
 $model->addField('all_actions', ['type' => 'boolean']);
 $model->addField('actions', ['type' => 'string']);
-$model->addField('conditions', ['type' => 'string']);
 
 (new Migrator($model))->create();
 $model->import([
-    ['id' => 1, 'role_id' => 1, 'model' => User::class, 'all_visible' => true, 'visible_fields' => null, 'all_editable' => false, 'editable_fields' => null, 'all_actions' => true, 'actions' => null, 'conditions' => null],
-    ['id' => 2, 'role_id' => 2, 'model' => User::class, 'all_visible' => true, 'visible_fields' => null, 'all_editable' => true, 'editable_fields' => null, 'all_actions' => true, 'actions' => null, 'conditions' => null],
-    ['id' => 3, 'role_id' => 2, 'model' => Role::class, 'all_visible' => true, 'visible_fields' => null, 'all_editable' => true, 'editable_fields' => null, 'all_actions' => true, 'actions' => null, 'conditions' => null],
+    ['id' => 1, 'role_id' => 1, 'model' => User::class, 'all_visible' => true, 'visible_fields' => null, 'all_editable' => false, 'editable_fields' => null, 'all_actions' => true, 'actions' => null],
+    ['id' => 2, 'role_id' => 2, 'model' => User::class, 'all_visible' => true, 'visible_fields' => null, 'all_editable' => true, 'editable_fields' => null, 'all_actions' => true, 'actions' => null],
+    ['id' => 3, 'role_id' => 2, 'model' => Role::class, 'all_visible' => true, 'visible_fields' => null, 'all_editable' => true, 'editable_fields' => null, 'all_actions' => true, 'actions' => null],
 ]);
 
 $model = new Model($db, ['table' => 'demo_client']);

--- a/demos/_demo-data/create-db.php
+++ b/demos/_demo-data/create-db.php
@@ -44,18 +44,18 @@ $model = new Model($db, ['table' => 'login_access_rule']);
 $model->addField('role_id', ['type' => 'integer']);
 $model->addField('model', ['type' => 'string']);
 $model->addField('all_visible', ['type' => 'boolean']);
-$model->addField('visible_fields', ['type' => 'boolean']);
+$model->addField('visible_fields', ['type' => 'string']);
 $model->addField('all_editable', ['type' => 'boolean']);
-$model->addField('editable_fields', ['type' => 'boolean']);
+$model->addField('editable_fields', ['type' => 'string']);
 $model->addField('all_actions', ['type' => 'boolean']);
-$model->addField('actions', ['type' => 'boolean']);
-$model->addField('conditions', ['type' => 'boolean']);
+$model->addField('actions', ['type' => 'string']);
+$model->addField('conditions', ['type' => 'string']);
 
 (new Migrator($model))->create();
 $model->import([
-    ['id' => 1, 'role_id' => 1, 'model' => User::class, 'all_visible' => 1, 'visible_fields' => null, 'all_editable' => 0, 'editable_fields' => null, 'all_actions' => 1, 'actions' => null, 'conditions' => null],
-    ['id' => 2, 'role_id' => 2, 'model' => User::class, 'all_visible' => 1, 'visible_fields' => null, 'all_editable' => 1, 'editable_fields' => null, 'all_actions' => 1, 'actions' => null, 'conditions' => null],
-    ['id' => 3, 'role_id' => 2, 'model' => Role::class, 'all_visible' => 1, 'visible_fields' => null, 'all_editable' => 1, 'editable_fields' => null, 'all_actions' => 1, 'actions' => null, 'conditions' => null],
+    ['id' => 1, 'role_id' => 1, 'model' => User::class, 'all_visible' => true, 'visible_fields' => null, 'all_editable' => false, 'editable_fields' => null, 'all_actions' => true, 'actions' => null, 'conditions' => null],
+    ['id' => 2, 'role_id' => 2, 'model' => User::class, 'all_visible' => true, 'visible_fields' => null, 'all_editable' => true, 'editable_fields' => null, 'all_actions' => true, 'actions' => null, 'conditions' => null],
+    ['id' => 3, 'role_id' => 2, 'model' => Role::class, 'all_visible' => true, 'visible_fields' => null, 'all_editable' => true, 'editable_fields' => null, 'all_actions' => true, 'actions' => null, 'conditions' => null],
 ]);
 
 $model = new Model($db, ['table' => 'demo_client']);

--- a/demos/acl-clients.php
+++ b/demos/acl-clients.php
@@ -22,4 +22,7 @@ $app->initAcl();
 Message::addTo($app, ['type' => 'info'])
     ->set('This is how an ACL managed app will look like based on logged in user and his role and permissions.');
 
+Message::addTo($app, ['type' => 'info'])
+    ->set('Currently logged-in user: ' . $app->auth->user->getTitle());
+
 Crud::addTo($app)->setModel(new Model\Client($app->db));

--- a/src/Acl.php
+++ b/src/Acl.php
@@ -31,7 +31,7 @@ class Acl
      *
      * @return list<array{model: string, all_visible: bool, visible_fields: list<string>, all_editable: bool, editable_fields: list<string>, all_actions: bool, actions: list<string>, conditions: list<string>}>
      */
-    public function getRules(Model $model): array
+    protected function getRules(Model $model): array
     {
         /** @var User */
         $user = $this->auth->user;

--- a/src/Acl.php
+++ b/src/Acl.php
@@ -31,7 +31,7 @@ class Acl
     /**
      * Returns array of AccessRules records for logged in user and in particular model scope.
      *
-     * @return array<int, array<string, mixed>>
+     * @return array<, array<model: string, all_visible: bool, visible_fields: list<string>, all_editable: bool, editable_fields: list<string>, all_actions: bool, actions: list<string>, conditions: list>>
      */
     public function getRules(Model $model): array
     {

--- a/src/Acl.php
+++ b/src/Acl.php
@@ -22,7 +22,8 @@ class Acl
     public $auth;
 
     /**
-     * Internal property to switch off ACL.
+     * @internal
+     *
      * Used for ACL models themself because ACL internally always needs full access to its models.
      */
     private bool $disabled = false;

--- a/src/Acl.php
+++ b/src/Acl.php
@@ -31,7 +31,16 @@ class Acl
     /**
      * Returns array of AccessRules records for logged in user and in particular model scope.
      *
-     * @return array<, array<model: string, all_visible: bool, visible_fields: list<string>, all_editable: bool, editable_fields: list<string>, all_actions: bool, actions: list<string>, conditions: list>>
+     * @return list<array{
+     *          model: string,
+     *          all_visible: bool,
+     *          visible_fields: list<string>,
+     *          all_editable: bool,
+     *          editable_fields: list<string>,
+     *          all_actions: bool,
+     *          actions: list<string>,
+     *          conditions: list
+     *      }>
      */
     public function getRules(Model $model): array
     {

--- a/src/Acl.php
+++ b/src/Acl.php
@@ -106,16 +106,4 @@ class Acl
             }
         }
     }
-
-    // Call $app->acl->can('admin'); for example to find out if user is allowed to admin things.
-    /*
-    public function can($feature)
-    {
-        if (!$this->permissions) {
-            $this->cachePermissions();
-        }
-
-        return $this->permissions[$feature] ?? false;
-    }
-    */
 }

--- a/src/Acl.php
+++ b/src/Acl.php
@@ -70,18 +70,12 @@ class Acl
     }
 
     /**
-     * @param list<string>|string|null $v
-     *
      * @return list<string>
      */
-    private function normalizeValue($v): array
+    private function normalizeValue(?string $v): array
     {
-        if (($v ?? '') === '') {
-            return [];
-        }
-
-        return is_array($v)
-            ? $v
+        return ($v ?? '') === ''
+            ? []
             : explode(',', $v);
     }
 

--- a/src/Acl.php
+++ b/src/Acl.php
@@ -29,6 +29,8 @@ class Acl
 
     /**
      * Returns array of AccessRules records for logged in user and in particular model scope.
+     *
+     * @return array<int, array<string, mixed>>
      */
     public function getRules(Model $model): array
     {
@@ -54,9 +56,27 @@ class Acl
         $rules = $user->ref('AccessRules')
             ->addCondition('model', 'in', $modelClasses)
             ->export(['model', 'all_visible', 'visible_fields', 'all_editable', 'editable_fields', 'all_actions', 'actions', 'conditions']);
+
+        // normalize
+        foreach ($rules as $k => $rule) {
+            $rules[$k]['visible_fields'] = $rule['all_visible'] ? [] : $this->normalizeValue($rule, 'visible_fields');
+            $rules[$k]['editable_fields'] = $rule['all_editable'] ? [] : $this->normalizeValue($rule, 'editable_fields');
+            $rules[$k]['actions'] = $rule['all_actions'] ? [] : $this->normalizeValue($rule, 'actions');
+        }
+
         $this->disabled = false;
 
         return $rules;
+    }
+
+    /**
+     * Normalize value.
+     */
+    private function normalizeValue(array $rule, string $field): array
+    {
+        $v = $rule[$field] ?? [];
+
+        return is_array($v) ? $v : explode(',', $v);
     }
 
     /**
@@ -71,24 +91,19 @@ class Acl
         }
 
         foreach ($this->getRules($m) as $rule) {
-            // extract as arrays
-            $visible = is_array($rule['visible_fields']) ? $rule['visible_fields'] : explode(',', $rule['visible_fields'] ?? '');
-            $editable = is_array($rule['editable_fields']) ? $rule['editable_fields'] : explode(',', $rule['editable_fields'] ?? '');
-            $actions = is_array($rule['actions']) ? $rule['actions'] : explode(',', $rule['actions'] ?? '');
-
             // set visible and editable fields
             foreach ($m->getFields() as $name => $field) {
-                if (!$rule['all_visible'] && $visible) {
-                    $field->ui['visible'] = array_search($name, $visible, true) !== false;
+                if ($rule['visible_fields']) {
+                    $field->ui['visible'] = array_search($name, $rule['visible_fields'], true) !== false;
                 }
-                if (!$rule['all_editable'] && $editable) {
-                    $field->ui['editable'] = array_search($name, $editable, true) !== false;
+                if ($rule['editable_fields']) {
+                    $field->ui['editable'] = array_search($name, $rule['editable_fields'], true) !== false;
                 }
             }
 
             // remove not allowed actions
-            if (!$rule['all_actions'] && $actions) {
-                $actions_to_remove = array_diff(array_keys($m->getUserActions()), $actions);
+            if ($rule['actions']) {
+                $actions_to_remove = array_diff(array_keys($m->getUserActions()), $rule['actions']);
                 foreach ($actions_to_remove as $action) {
                     $m->getUserAction($action)->enabled = false;
                 }

--- a/src/Acl.php
+++ b/src/Acl.php
@@ -70,11 +70,13 @@ class Acl
     }
 
     /**
-     * @param mixed $v
+     * @param list<string>|string|null $v
+     *
+     * @return list<string>
      */
     private function normalizeValue($v): array
     {
-        return is_array($v) ? $v : explode(',', $v);
+        return is_array($v) ? $v : explode(',', $v ?? null);
     }
 
     /**

--- a/src/Acl.php
+++ b/src/Acl.php
@@ -6,7 +6,6 @@ namespace Atk4\Login;
 
 use Atk4\Data\Exception;
 use Atk4\Data\Model;
-use Atk4\Login\Model\AccessRule;
 use Atk4\Login\Model\User;
 
 /**
@@ -23,11 +22,15 @@ class Acl
     public $auth;
 
     /**
-     * Returns AccessRules model for logged in user and in model scope.
-     *
-     * @return AccessRule
+     * Internal property to switch off ACL.
+     * Used for ACL models themself because ACL internally always needs full access to its models.
      */
-    public function getRules(Model $model)
+    private bool $disabled = false;
+
+    /**
+     * Returns array of AccessRules records for logged in user and in particular model scope.
+     */
+    public function getRules(Model $model): array
     {
         /** @var User */
         $user = $this->auth->user;
@@ -45,9 +48,15 @@ class Acl
                 $modelClasses[] = $class;
             }
         } while (($class = get_parent_class($class)) !== false);
-        $res = $user->ref('AccessRules')->addCondition('model', 'in', $modelClasses);
 
-        return $res; // @phpstan-ignore-line
+        // Internally disable ACL for a moment and limit to only required fields to avoid recursion
+        $this->disabled = true;
+        $rules = $user->ref('AccessRules')
+            ->addCondition('model', 'in', $modelClasses)
+            ->export(['model', 'all_visible', 'visible_fields', 'all_editable', 'editable_fields', 'all_actions', 'actions', 'conditions']);
+        $this->disabled = false;
+
+        return $rules;
     }
 
     /**
@@ -57,24 +66,28 @@ class Acl
      */
     public function applyRestrictions(Model $m): void
     {
+        if ($this->disabled) {
+            return;
+        }
+
         foreach ($this->getRules($m) as $rule) {
             // extract as arrays
-            $visible = is_array($rule->get('visible_fields')) ? $rule->get('visible_fields') : explode(',', $rule->get('visible_fields') ?? '');
-            $editable = is_array($rule->get('editable_fields')) ? $rule->get('editable_fields') : explode(',', $rule->get('editable_fields') ?? '');
-            $actions = is_array($rule->get('actions')) ? $rule->get('actions') : explode(',', $rule->get('actions') ?? '');
+            $visible = is_array($rule['visible_fields']) ? $rule['visible_fields'] : explode(',', $rule['visible_fields'] ?? '');
+            $editable = is_array($rule['editable_fields']) ? $rule['editable_fields'] : explode(',', $rule['editable_fields'] ?? '');
+            $actions = is_array($rule['actions']) ? $rule['actions'] : explode(',', $rule['actions'] ?? '');
 
             // set visible and editable fields
             foreach ($m->getFields() as $name => $field) {
-                if (!$rule->get('all_visible') && $visible) {
+                if (!$rule['all_visible'] && $visible) {
                     $field->ui['visible'] = array_search($name, $visible, true) !== false;
                 }
-                if (!$rule->get('all_editable') && $editable) {
+                if (!$rule['all_editable'] && $editable) {
                     $field->ui['editable'] = array_search($name, $editable, true) !== false;
                 }
             }
 
             // remove not allowed actions
-            if (!$rule->get('all_actions') && $actions) {
+            if (!$rule['all_actions'] && $actions) {
                 $actions_to_remove = array_diff(array_keys($m->getUserActions()), $actions);
                 foreach ($actions_to_remove as $action) {
                     $m->getUserAction($action)->enabled = false;

--- a/src/Acl.php
+++ b/src/Acl.php
@@ -29,7 +29,7 @@ class Acl
     /**
      * Returns array of AccessRules records for logged in user and in particular model scope.
      *
-     * @return list<array{model: string, all_visible: bool, visible_fields: list<string>, all_editable: bool, editable_fields: list<string>, all_actions: bool, actions: list<string>, conditions: list<string>}>
+     * @return list<array{model: class-string<Model>, all_visible: bool, visible_fields: list<string>, all_editable: bool, editable_fields: list<string>, all_actions: bool, actions: list<string>, conditions: list<string>}>
      */
     protected function getRules(Model $model): array
     {

--- a/src/Acl.php
+++ b/src/Acl.php
@@ -23,24 +23,13 @@ class Acl
 
     /**
      * @internal
-     *
-     * Used for ACL models themself because ACL internally always needs full access to its models
      */
-    private bool $disabled = false;
+    private bool $skipApplyRestrictionsForRulesExport = false;
 
     /**
      * Returns array of AccessRules records for logged in user and in particular model scope.
      *
-     * @return list<array{
-     *          model: string,
-     *          all_visible: bool,
-     *          visible_fields: list<string>,
-     *          all_editable: bool,
-     *          editable_fields: list<string>,
-     *          all_actions: bool,
-     *          actions: list<string>,
-     *          conditions: list
-     *      }>
+     * @return list<array{model: string, all_visible: bool, visible_fields: list<string>, all_editable: bool, editable_fields: list<string>, all_actions: bool, actions: list<string>, conditions: list<string>}>
      */
     public function getRules(Model $model): array
     {
@@ -61,28 +50,31 @@ class Acl
             }
         } while (($class = get_parent_class($class)) !== false);
 
-        // Internally disable ACL for a moment and limit to only required fields to avoid recursion
-        $this->disabled = true;
-        $rules = $user->ref('AccessRules')
-            ->addCondition('model', 'in', $modelClasses)
-            ->export(['model', 'all_visible', 'visible_fields', 'all_editable', 'editable_fields', 'all_actions', 'actions', 'conditions']);
+        try {
+            $this->skipApplyRestrictionsForRulesExport = true;
 
-        // normalize
-        foreach ($rules as $k => $rule) {
-            $rules[$k]['visible_fields'] = $rule['all_visible'] ? [] : $this->normalizeValue($rule, 'visible_fields');
-            $rules[$k]['editable_fields'] = $rule['all_editable'] ? [] : $this->normalizeValue($rule, 'editable_fields');
-            $rules[$k]['actions'] = $rule['all_actions'] ? [] : $this->normalizeValue($rule, 'actions');
+            $rules = $user->ref('AccessRules')
+                ->addCondition('model', 'in', $modelClasses)
+                ->export(['model', 'all_visible', 'visible_fields', 'all_editable', 'editable_fields', 'all_actions', 'actions', 'conditions']);
+
+            // normalize
+            foreach ($rules as $k => $rule) {
+                $rules[$k]['visible_fields'] = $rule['all_visible'] ? [] : $this->normalizeValue($rule['visible_fields']);
+                $rules[$k]['editable_fields'] = $rule['all_editable'] ? [] : $this->normalizeValue($rule['editable_fields']);
+                $rules[$k]['actions'] = $rule['all_actions'] ? [] : $this->normalizeValue($rule['actions']);
+            }
+        } finally {
+            $this->skipApplyRestrictionsForRulesExport = false;
         }
-
-        $this->disabled = false;
 
         return $rules;
     }
 
-    private function normalizeValue(array $rule, string $field): array
+    /**
+     * @param mixed $v
+     */
+    private function normalizeValue($v): array
     {
-        $v = $rule[$field] ?? [];
-
         return is_array($v) ? $v : explode(',', $v);
     }
 
@@ -93,23 +85,23 @@ class Acl
      */
     public function applyRestrictions(Model $m): void
     {
-        if ($this->disabled) {
+        if ($this->skipApplyRestrictionsForRulesExport) {
             return;
         }
 
         foreach ($this->getRules($m) as $rule) {
             // set visible and editable fields
             foreach ($m->getFields() as $name => $field) {
-                if ($rule['visible_fields']) {
-                    $field->ui['visible'] = array_search($name, $rule['visible_fields'], true) !== false;
+                if ($rule['visible_fields'] !== [] && array_search($name, $rule['visible_fields'], true) === false) {
+                    $field->ui['visible'] = false;
                 }
-                if ($rule['editable_fields']) {
-                    $field->ui['editable'] = array_search($name, $rule['editable_fields'], true) !== false;
+                if ($rule['editable_fields'] !== [] && array_search($name, $rule['editable_fields'], true) === false) {
+                    $field->ui['editable'] = false;
                 }
             }
 
             // remove not allowed actions
-            if ($rule['actions']) {
+            if ($rule['actions'] !== []) {
                 $actions_to_remove = array_diff(array_keys($m->getUserActions()), $rule['actions']);
                 foreach ($actions_to_remove as $action) {
                     $m->getUserAction($action)->enabled = false;

--- a/src/Acl.php
+++ b/src/Acl.php
@@ -56,11 +56,10 @@ class Acl
                 ->addCondition('model', 'in', $modelClasses)
                 ->export(['model', 'all_visible', 'visible_fields', 'all_editable', 'editable_fields', 'all_actions', 'actions', 'conditions']);
 
-            // normalize
             foreach ($rules as $k => $rule) {
-                $rules[$k]['visible_fields'] = $rule['all_visible'] ? [] : $this->normalizeValue($rule['visible_fields']);
-                $rules[$k]['editable_fields'] = $rule['all_editable'] ? [] : $this->normalizeValue($rule['editable_fields']);
-                $rules[$k]['actions'] = $rule['all_actions'] ? [] : $this->normalizeValue($rule['actions']);
+                $rules[$k]['visible_fields'] = $rule['all_visible'] ? [] : $this->explodeValue($rule['visible_fields']);
+                $rules[$k]['editable_fields'] = $rule['all_editable'] ? [] : $this->explodeValue($rule['editable_fields']);
+                $rules[$k]['actions'] = $rule['all_actions'] ? [] : $this->explodeValue($rule['actions']);
             }
         } finally {
             $this->skipApplyRestrictionsForRulesExport = false;
@@ -72,7 +71,7 @@ class Acl
     /**
      * @return list<string>
      */
-    private function normalizeValue(?string $v): array
+    private function explodeValue(?string $v): array
     {
         return ($v ?? '') === ''
             ? []

--- a/src/Acl.php
+++ b/src/Acl.php
@@ -24,7 +24,7 @@ class Acl
     /**
      * @internal
      *
-     * Used for ACL models themself because ACL internally always needs full access to its models.
+     * Used for ACL models themself because ACL internally always needs full access to its models
      */
     private bool $disabled = false;
 

--- a/src/Acl.php
+++ b/src/Acl.php
@@ -76,7 +76,9 @@ class Acl
      */
     private function normalizeValue($v): array
     {
-        return is_array($v) ? $v : explode(',', $v ?? null);
+        return is_array($v)
+            ? $v
+            : explode(',', $v ?? null);
     }
 
     /**

--- a/src/Acl.php
+++ b/src/Acl.php
@@ -69,9 +69,6 @@ class Acl
         return $rules;
     }
 
-    /**
-     * Normalize value.
-     */
     private function normalizeValue(array $rule, string $field): array
     {
         $v = $rule[$field] ?? [];

--- a/src/Acl.php
+++ b/src/Acl.php
@@ -50,9 +50,8 @@ class Acl
             }
         } while (($class = get_parent_class($class)) !== false);
 
+        $this->skipApplyRestrictionsForRulesExport = true;
         try {
-            $this->skipApplyRestrictionsForRulesExport = true;
-
             $rules = $user->ref('AccessRules')
                 ->addCondition('model', 'in', $modelClasses)
                 ->export(['model', 'all_visible', 'visible_fields', 'all_editable', 'editable_fields', 'all_actions', 'actions', 'conditions']);

--- a/src/Acl.php
+++ b/src/Acl.php
@@ -76,9 +76,13 @@ class Acl
      */
     private function normalizeValue($v): array
     {
+        if (($v ?? '') === '') {
+            return [];
+        }
+
         return is_array($v)
             ? $v
-            : explode(',', $v ?? null);
+            : explode(',', $v);
     }
 
     /**

--- a/src/Acl.php
+++ b/src/Acl.php
@@ -26,7 +26,7 @@ class Acl
     /**
      * Returns array of AccessRules records for logged in user and in particular model scope.
      *
-     * @return list<array{model: class-string<Model>, all_visible: bool, visible_fields: list<string>, all_editable: bool, editable_fields: list<string>, all_actions: bool, actions: list<string>, conditions: list<string>}>
+     * @return list<array{model: class-string<Model>, all_visible: bool, visible_fields: list<string>, all_editable: bool, editable_fields: list<string>, all_actions: bool, actions: list<string>}>
      */
     protected function getRules(Model $model): array
     {
@@ -51,7 +51,7 @@ class Acl
         try {
             $rules = $user->ref('AccessRules')
                 ->addCondition('model', 'in', $modelClasses)
-                ->export(['model', 'all_visible', 'visible_fields', 'all_editable', 'editable_fields', 'all_actions', 'actions', 'conditions']);
+                ->export(['model', 'all_visible', 'visible_fields', 'all_editable', 'editable_fields', 'all_actions', 'actions']);
 
             foreach ($rules as $k => $rule) {
                 $rules[$k]['visible_fields'] = $rule['all_visible'] ? [] : $this->explodeValue($rule['visible_fields']);
@@ -104,24 +104,7 @@ class Acl
                     $m->getUserAction($action)->enabled = false;
                 }
             }
-
-            // add conditions on model
-            /* this will work in future when we will have json encoded condition structure stored in here
-            if ($rule['conditions']) {
-                $this->applyConditions($m, $rule['conditions']);
-            }
-            */
         }
-    }
-
-    /**
-     * Apply conditions on model.
-     *
-     * @param mixed $conditions
-     */
-    public function applyConditions(Model $m, $conditions): void
-    {
-        $m->addCondition($conditions);
     }
 
     // Call $app->acl->can('admin'); for example to find out if user is allowed to admin things.

--- a/src/Acl.php
+++ b/src/Acl.php
@@ -21,9 +21,6 @@ class Acl
      */
     public $auth;
 
-    /**
-     * @internal
-     */
     private bool $skipApplyRestrictionsForRulesExport = false;
 
     /**

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -117,7 +117,7 @@ class Auth
      *
      * @return $this
      */
-    public function setModel(Model $model, string $fieldLogin = null, string $fieldPassword = null)
+    public function setModel(Model $model, ?string $fieldLogin = null, ?string $fieldPassword = null)
     {
         if ($this->user !== null) {
             throw new Exception('Model is already set');
@@ -231,7 +231,7 @@ class Auth
      *
      * @return $this
      */
-    public function setAcl(Acl $acl, Persistence $persistence = null)
+    public function setAcl(Acl $acl, ?Persistence $persistence = null)
     {
         $persistence ??= $this->user->getModel()->getPersistence();
         $acl->auth = $this;

--- a/src/Feature/SetupAccessRuleModelTrait.php
+++ b/src/Feature/SetupAccessRuleModelTrait.php
@@ -35,7 +35,6 @@ trait SetupAccessRuleModelTrait
         $this->getField('visible_fields')->ui['form'] = [Control\Fields::class];
         $this->getField('editable_fields')->ui['form'] = [Control\Fields::class];
         $this->getField('actions')->ui['form'] = [Control\Actions::class];
-        $this->getField('conditions')->type = 'text';
 
         // cleanup data
         $this->onHook(Model::HOOK_BEFORE_SAVE, static function (self $m) {

--- a/src/Feature/SetupAccessRuleModelTrait.php
+++ b/src/Feature/SetupAccessRuleModelTrait.php
@@ -38,6 +38,7 @@ trait SetupAccessRuleModelTrait
 
         // cleanup data
         $this->onHook(Model::HOOK_BEFORE_SAVE, static function (self $m) {
+            // @todo this is not always right way to normalize data
             if ($m->get('all_visible')) {
                 $m->setNull('visible_fields');
             }

--- a/src/Form/Control/Actions.php
+++ b/src/Form/Control/Actions.php
@@ -30,6 +30,8 @@ class Actions extends GenericDropdown
         if ($model) {
             $actions = array_keys($model->getUserActions());
             $this->values = array_combine($actions, $actions);
+        } else {
+            $this->values = [];
         }
 
         parent::renderView();

--- a/src/Form/Control/Fields.php
+++ b/src/Form/Control/Fields.php
@@ -30,6 +30,8 @@ class Fields extends GenericDropdown
         if ($model) {
             $fields = array_keys($model->getFields());
             $this->values = array_combine($fields, $fields);
+        } else {
+            $this->values = [];
         }
 
         parent::renderView();

--- a/src/Form/Register.php
+++ b/src/Form/Register.php
@@ -38,7 +38,7 @@ class Register extends Form
     }
 
     #[\Override]
-    public function setModel(Model $user, array $fields = null): void
+    public function setModel(Model $user, ?array $fields = null): void
     {
         parent::setModel($user, []);
 

--- a/src/Model/AccessRule.php
+++ b/src/Model/AccessRule.php
@@ -62,10 +62,6 @@ class AccessRule extends Model
         $this->addField('all_actions', ['type' => 'boolean']);
         $this->addField('actions'); // used if all_actions is false
 
-        // Specify which conditions will be applied on the model, e.g. "status=DRAFT AND sent=true OR status=SENT"
-        // @TODO this will be replaced by JSON structure when Alain will develop such JS widget
-        $this->addField('conditions');
-
         $this->setupAccessRuleModel();
     }
 }

--- a/src/Model/AccessRule.php
+++ b/src/Model/AccessRule.php
@@ -35,7 +35,7 @@ class AccessRule extends Model
         $this->addField('model'); // model class name
 
         /*
-         * @TODO maybe all_visible and visible_fields can be replaced with just on field visible:
+         * @TODO maybe all_visible and visible_fields can be replaced with just one field visible:
          *      '*' - equals all_fields=true
          *      'foo,bar' - equals visible_fields='foo,bar' or visible_fields=['foo', 'bar']
          *

--- a/src/RoleAdmin.php
+++ b/src/RoleAdmin.php
@@ -23,7 +23,7 @@ class RoleAdmin extends Crud
      * Initialize User Admin and add all the UI pieces.
      */
     #[\Override]
-    public function setModel(Model $role, array $fields = null): void
+    public function setModel(Model $role, ?array $fields = null): void
     {
         parent::setModel($role);
 

--- a/tests/GenericTestCase.php
+++ b/tests/GenericTestCase.php
@@ -78,9 +78,9 @@ abstract class GenericTestCase extends BaseTestCase
                 ['id' => 2, 'name' => 'Administrator', 'email' => 'admin', 'password' => '$2y$10$p34ciRcg9GZyxukkLIaEnenGBao79fTFa4tFSrl7FvqrxnmEGlD4O' /* admin */, 'role_id' => 2, 'last_login' => null],
             ],
             self::getTableByStandardModelClass(AccessRule::class) => [
-                ['id' => 1, 'role_id' => 1, 'model' => User::class, 'all_visible' => true, 'visible_fields' => null, 'all_editable' => false, 'editable_fields' => 'vat_number,active', 'all_actions' => true, 'actions' => null, 'conditions' => null],
-                ['id' => 2, 'role_id' => 2, 'model' => User::class, 'all_visible' => true, 'visible_fields' => null, 'all_editable' => false, 'editable_fields' => null, 'all_actions' => true, 'actions' => null, 'conditions' => null],
-                ['id' => 3, 'role_id' => 2, 'model' => Role::class, 'all_visible' => true, 'visible_fields' => null, 'all_editable' => true, 'editable_fields' => null, 'all_actions' => true, 'actions' => null, 'conditions' => null],
+                ['id' => 1, 'role_id' => 1, 'model' => User::class, 'all_visible' => true, 'visible_fields' => null, 'all_editable' => false, 'editable_fields' => 'vat_number,active', 'all_actions' => true, 'actions' => null],
+                ['id' => 2, 'role_id' => 2, 'model' => User::class, 'all_visible' => true, 'visible_fields' => null, 'all_editable' => false, 'editable_fields' => null, 'all_actions' => true, 'actions' => null],
+                ['id' => 3, 'role_id' => 2, 'model' => Role::class, 'all_visible' => true, 'visible_fields' => null, 'all_editable' => true, 'editable_fields' => null, 'all_actions' => true, 'actions' => null],
             ],
         ]);
     }


### PR DESCRIPTION
introduced in https://github.com/atk4/core/pull/246

BC break - `Acl->getRules()` now returns array of records instead of `AccessRule` model.
* that way we avoid recursion
* also it's much safer because we should not give access to unconditioned AccessRule model
* in future we can simply implement some optional caching mechanism if needed and simply store users rules data array somewhere