### PR TITLE
Set default table name

### DIFF
--- a/src/Form/Control/GenericDropdown.php
+++ b/src/Form/Control/GenericDropdown.php
@@ -33,7 +33,7 @@ abstract class GenericDropdown extends Form\Control\Dropdown
             return null;
         }
 
-        $model = new $class($this->form->entity->getModel()->getPersistence());
+        $model = new $class($this->form->entity->getModel()->getPersistence(), ['table' => '']);
         if (!$model instanceof Model) {
             throw new Exception('Class must be instance of ' . Model::class);
         }


### PR DESCRIPTION
If you define rules on default Atk4\Data\Model class, then it do not have $table set and will fail.
That's why we should set some fake default table name.